### PR TITLE
Update file to allow plotting of 'id's other than 1

### DIFF
--- a/R/plot_individual_variable_effect.R
+++ b/R/plot_individual_variable_effect.R
@@ -113,7 +113,7 @@ plot.individual_variable_effect <-
     if (show_predicted == TRUE) {
       levels(x$`_ext_vname_`) <- c(levels(x$`_ext_vname_`), "_predicted_")
       for (i in 1:length(id)) {
-        x_pred <- x[id == i, ]
+        x_pred <- x[x$`_id_`  == id[i], ]
         x_pred$`_ext_vname_` <-
           factor("_predicted_", levels = levels(x$`_ext_vname_`))
         x_pred$`_attribution_` <-


### PR DESCRIPTION
Here is a reproducible example of the error that this proposed fix solves:

```{r }
Y_train <- HR$status
x_train <- HR[ , -6]
set.seed(123)
model_rf <- randomForest(x = x_train, y = Y_train, ntree = 50)
p_function <- function(model, data) predict(model, newdata = data, type = "prob")

ive_rf <- individual_variable_effect(model_rf, data = x_train, predict_function = p_function,
                                   new_observation = x_train[1:2,], nsamples = 50)

plot(ive_rf, id = 1)
plot(ive_rf, id = 2) # error, this is solved with the propsed fix
```